### PR TITLE
WIP feat: allow shoppable image to be used in editor extension view

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/uuid": "^8.3.4",
     "clsx": "^1.1.1",
-    "dc-extensions-sdk": "^2.0.0",
+    "dc-extensions-sdk": "^2.1.0",
     "dc-visualization-sdk": "^1.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/core/ExtensionSdk.ts
+++ b/src/core/ExtensionSdk.ts
@@ -1,8 +1,8 @@
-import { init, ContentFieldExtension } from 'dc-extensions-sdk';
+import { init, ContentFieldExtension, ContentEditorExtension } from 'dc-extensions-sdk';
 
-let sdk: Promise<ContentFieldExtension>;
+let sdk: Promise<ContentFieldExtension | ContentEditorExtension>;
 
-export async function getSdk(): Promise<ContentFieldExtension> {
+export async function getSdk(): Promise<ContentFieldExtension | ContentEditorExtension> {
   if (sdk == null) {
     sdk = init();
   }

--- a/src/preview/edit-toolbar/edit-toolbar.css
+++ b/src/preview/edit-toolbar/edit-toolbar.css
@@ -5,6 +5,7 @@
 .amp-edit-toolbar {
   transition: margin-top 0.5s;
   margin-top: 0;
+  border-top: 1px solid white;
   display: flex;
   position: relative;
   z-index: 1;

--- a/src/preview/mode-buttons/mode-buttons.css
+++ b/src/preview/mode-buttons/mode-buttons.css
@@ -15,12 +15,21 @@
   z-index: 101;
 }
 
+.amp-mode-buttons.empty {
+  opacity: 1;
+  background-color: inherit;
+}
+
 .amp-mode-buttons button {
   margin: 10px;
 }
 
 .amp-mode-buttons:hover {
   opacity: 1;
+}
+
+.amp-mode-buttons.empty:hover {
+  background-color: rgba(41,51,63,.8);
 }
 
 .amp-mode-buttons__hide {

--- a/src/preview/mode-buttons/mode-buttons.tsx
+++ b/src/preview/mode-buttons/mode-buttons.tsx
@@ -13,7 +13,7 @@ export function ModeButtons() {
   const { mode, changeMode } = useEditorContext();
 
   const showButtons = mode === EditorMode.Initial;
-  const hasImage = field && field.image.id;
+  const hasImage = field?.image?.id;
 
   const modeButton = async (mode: EditorMode): Promise<void> => {
     if (sdk && field && setField && clearUndo) {
@@ -49,7 +49,7 @@ export function ModeButtons() {
   }
 
   return (
-    <div className="amp-mode-buttons">
+    <div className={`amp-mode-buttons ${!hasImage ? 'empty' : ''}`}>
       {hasImage && (
         <>
           <Tooltip title="Edit image & focal point">

--- a/src/preview/preview-canvas/preview-canvas.css
+++ b/src/preview/preview-canvas/preview-canvas.css
@@ -5,6 +5,7 @@
   align-items: center;
   overflow: hidden;
   position: relative;
+  background: whitesmoke;
 }
 
 .amp-preview-canvas__image {
@@ -13,6 +14,7 @@
   opacity: 1;
   transition: opacity 0.33s;
   position: absolute;
+  background: white;
 }
 
 .amp-preview-canvas__image--hide {

--- a/src/preview/preview-canvas/preview-canvas.tsx
+++ b/src/preview/preview-canvas/preview-canvas.tsx
@@ -671,7 +671,7 @@ export function PreviewCanvas() {
 
   let image: JSX.Element | undefined;
   let src = "invalid";
-  if (field && field.image.id) {
+  if (field?.image?.id) {
     const imageHost = sdk?.stagingEnvironment || field.image.defaultHost;
     src = `https://${imageHost}/i/${field.image.endpoint}/${encodeURIComponent(
       field.image.name

--- a/src/preview/title/title.tsx
+++ b/src/preview/title/title.tsx
@@ -2,10 +2,10 @@ import "./title.css";
 import { useExtensionContext } from "../../core/ExtensionContext";
 
 export function Title() {
-  const { params } = useExtensionContext();
+  const { params, isField } = useExtensionContext();
   const title = params?.title;
 
-  return title != null ? (
+  return title != null && isField ? (
     <div className="amp-title">{title}</div>
   ) : (
     <></>

--- a/src/visualization/vis-page/vis-page.tsx
+++ b/src/visualization/vis-page/vis-page.tsx
@@ -188,7 +188,7 @@ export function VisPage({ vse, hotspotHide, scaleToFit }: { vse: string, hotspot
 
   let image: JSX.Element | undefined;
   let src = "invalid";
-  if (field && field.image.id) {
+  if (field?.image?.id) {
     const imageHost = vse || field.image.defaultHost;
     src = `https://${imageHost}/i/${field.image.endpoint}/${encodeURIComponent(
       field.image.name


### PR DESCRIPTION
- Needs UAT
- Tweaks UI so editor is not blank when empty
- Known issue where `{_empty}` needs to be removed due to different cleanup processes between editor engines