### PR TITLE
chore: use node 16.x as default

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -11,13 +11,13 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension allows users to define Focal Points and interactable Hotspots ove
 
 If you want to get started after cloning this repo, remember to sync packages with `yarn install`.
 
-This project requires Node 14.x or 16.x to build.
+This project requires Node 16.x to build.
 
 ## Partial for Shoppabble Image Field and Configuration
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This extension allows users to define Focal Points and interactable Hotspots ove
 
 If you want to get started after cloning this repo, remember to sync packages with `yarn install`.
 
+This project requires Node 14.x or 16.x to build.
+
 ## Partial for Shoppabble Image Field and Configuration
 
 The shoppable image extension has a rather complicated structure for the field it writes, so it's recommended that you put the schema in a partial. You can find the full partial definition in `shoppable-image-partial.json` in the base of this repository.

--- a/amplify.yml
+++ b/amplify.yml
@@ -3,8 +3,8 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm install 14
-        - nvm use 14
+        - nvm install 16
+        - nvm use 16
         - yarn install --immutable
         - yarn test
     build:


### PR DESCRIPTION
Updates the default node version to node 16.x. 