### PR TITLE
fix: updates extension to consume and save back undefined value

### DIFF
--- a/src/core/EditorContext.tsx
+++ b/src/core/EditorContext.tsx
@@ -106,7 +106,7 @@ export function WithEditorContext({ children }: { children: React.ReactNode }) {
         category: "Extension",
       });
 
-      const imageHost = sdk?.stagingEnvironment || field?.image.defaultHost;
+      const imageHost = sdk?.stagingEnvironment || field?.image?.defaultHost;
       if (
         AIService &&
         imageHost &&

--- a/src/core/ExtensionContext.tsx
+++ b/src/core/ExtensionContext.tsx
@@ -52,8 +52,9 @@ export function WithExtensionContext({
         const schema = sdk.field.schema;
         const formValue = (await sdk.field.getValue()) as ShoppableImageData;
         let hasImage = !!formValue?.image?.id;
-        const asset = hasImage
-          ? await sdk.assets.getById(formValue?.image?.id || '')
+        const assetId = formValue?.image?.id;
+        const asset = hasImage && assetId
+          ? await sdk.assets.getById(assetId)
           : {};
         const thumbURL = asset.thumbURL;
         const field = formValue || {};

--- a/src/core/ExtensionContext.tsx
+++ b/src/core/ExtensionContext.tsx
@@ -51,13 +51,12 @@ export function WithExtensionContext({
         };
         const schema = sdk.field.schema;
         const formValue = (await sdk.field.getValue()) as ShoppableImageData;
-        const hasImage = !(formValue as { image: { _empty?: boolean } }).image
-          ?._empty;
+        let hasImage = !!formValue?.image?.id;
         const asset = hasImage
-          ? await sdk.assets.getById(formValue.image.id)
+          ? await sdk.assets.getById(formValue?.image?.id || '')
           : {};
         const thumbURL = asset.thumbURL;
-        const field = formValue;
+        const field = formValue || {};
         const undoHistory: ShoppableImageData[] = [];
         const redoHistory: ShoppableImageData[] = [];
         const AIService = new AIRequestService(sdk, params?.ai?.basePath || "");

--- a/src/core/ShoppableImageData.ts
+++ b/src/core/ShoppableImageData.ts
@@ -27,7 +27,7 @@ export interface ShoppableImagePolygon {
 }
 
 export interface ShoppableImageData {
-  image: MediaImageLink | undefined;
+  image?: MediaImageLink;
   poi?: ShoppableImagePoi;
   hotspots?: ShoppableImageHotspot[];
   polygons?: ShoppableImagePolygon[];

--- a/src/core/ShoppableImageData.ts
+++ b/src/core/ShoppableImageData.ts
@@ -27,7 +27,7 @@ export interface ShoppableImagePolygon {
 }
 
 export interface ShoppableImageData {
-  image: MediaImageLink;
+  image: MediaImageLink | undefined;
   poi?: ShoppableImagePoi;
   hotspots?: ShoppableImageHotspot[];
   polygons?: ShoppableImagePolygon[];

--- a/src/preview/mode-buttons/mode-buttons.tsx
+++ b/src/preview/mode-buttons/mode-buttons.tsx
@@ -21,7 +21,7 @@ export function ModeButtons() {
   const handleMouseLeave = () => setHover(false);
 
   const showButtons = mode === EditorMode.Initial;
-  const hasImage = field && field.image.id;
+  const hasImage = field && field?.image?.id;
 
   const modeButton = async (mode: EditorMode): Promise<void> => {
     if (sdk && field && setField && clearUndo) {
@@ -42,7 +42,7 @@ export function ModeButtons() {
           changeMode(EditorMode.EditorPoi);
           break;
         case EditorMode.Delete:
-          field.image = { _empty: true } as any;
+          field.image = undefined;
           field.poi = {} as any;
           field.hotspots = [];
           field.polygons = [];

--- a/src/preview/preview-canvas/preview-canvas.tsx
+++ b/src/preview/preview-canvas/preview-canvas.tsx
@@ -673,7 +673,7 @@ export function PreviewCanvas() {
 
   let image: JSX.Element | undefined;
   let src = "invalid";
-  if (field && field.image.id) {
+  if (field && field?.image?.id) {
     src = sdk?.stagingEnvironment
       ? `https://${sdk.stagingEnvironment}/i/${
           field.image.endpoint

--- a/src/visualization/vis-page/vis-page.tsx
+++ b/src/visualization/vis-page/vis-page.tsx
@@ -208,7 +208,7 @@ export function VisPage({
 
   let image: JSX.Element | undefined;
   let src = "invalid";
-  if (field && field.image.id) {
+  if (field && field?.image?.id) {
     src = vse
       ? `https://${vse}/i/${field.image.endpoint}/${encodeURIComponent(
           field.image.name


### PR DESCRIPTION
# Summary of changes
- updates extension to consume and save back undefined value instead of _empty true object

- adds optional chaining to any checks around an images asset id as this was causing javascript errors when removing an image